### PR TITLE
Completed database worksheet

### DIFF
--- a/prisma/migrations/20240606180414_nullmembers_allowed/migration.sql
+++ b/prisma/migrations/20240606180414_nullmembers_allowed/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Made the column `memberId` on table `books` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "books" DROP CONSTRAINT "books_memberId_fkey";
+
+-- AlterTable
+ALTER TABLE "books" ALTER COLUMN "memberId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "books" ADD CONSTRAINT "books_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "Member"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,8 +20,8 @@ model Book {
   genres   GenresOnBooks[]
   Author   Author?         @relation(fields: [authorId], references: [id])
   authorId Int?
-  Member   Member?         @relation(fields: [memberId], references: [id])
-  memberId String?
+  Member   Member          @relation(fields: [memberId], references: [id])
+  memberId String
 
   @@map("books")
 }

--- a/script.ts
+++ b/script.ts
@@ -49,7 +49,6 @@ async function main() {
             email: "member@member.com",
             address: "address,street,zip",
             booksRented: {
-
                
 
             },

--- a/script.ts
+++ b/script.ts
@@ -14,6 +14,16 @@ async function main() {
     
       })
 
+      const author2 = await prisma.author.create({
+
+        data: {
+        
+            name: "joe mama",
+            Bio: "writes books for fun"
+        },
+    
+      })
+
     const member = await prisma.member.create({
 
         data:{

--- a/script.ts
+++ b/script.ts
@@ -37,6 +37,23 @@ async function main() {
 
             },
 
+        }
+
+    })
+
+    const member3 = await prisma.member.create({
+
+        data:{
+
+            name: "Member 1",
+            email: "member@member.com",
+            address: "address,street,zip",
+            booksRented: {
+
+               
+
+            },
+
 
         }
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 416c04b028c117a448842c220d1c9e20b52a757d  | 
|--------|--------|

### Summary:
This PR makes the `memberId` field in the `books` table non-nullable and updates the Prisma schema and seed script accordingly.

**Key points**:
- Updated `prisma/migrations/20240606180414_nullmembers_allowed/migration.sql` to make `memberId` non-nullable in `books` table.
- Modified `prisma/schema.prisma` to reflect non-nullable `memberId` in `Book` model.
- Added new author and member creation in `script.ts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
